### PR TITLE
feat(pwa): add manifest, service-worker, offline fallback, and install prompt

### DIFF
--- a/tt-travels/index.html
+++ b/tt-travels/index.html
@@ -2,8 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="./vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="manifest" href="./manifest.json" />
+    <meta name="theme-color" content="#0f172a" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="TTTravel" />
     <title>TT's Travels</title>
   </head>
   <body>

--- a/tt-travels/public/manifest.json
+++ b/tt-travels/public/manifest.json
@@ -1,0 +1,18 @@
+{
+  "name": "TT's Travels",
+  "short_name": "TTTravel",
+  "description": "Plan trips, manage journals, and explore travel ideas from any device.",
+  "start_url": "./",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#0f172a",
+  "icons": [
+    {
+      "src": "./vite.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/tt-travels/public/offline.html
+++ b/tt-travels/public/offline.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Offline | TT's Travels</title>
+    <style>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+        background: #0f172a;
+        color: #f8fafc;
+        padding: 1.5rem;
+      }
+      main {
+        max-width: 32rem;
+        text-align: center;
+      }
+      h1 {
+        margin-bottom: 0.75rem;
+      }
+      p {
+        line-height: 1.6;
+        opacity: 0.9;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>You're offline</h1>
+      <p>TT's Travels is unavailable right now. Reconnect to continue planning and syncing your trip data.</p>
+    </main>
+  </body>
+</html>

--- a/tt-travels/public/service-worker.js
+++ b/tt-travels/public/service-worker.js
@@ -1,0 +1,137 @@
+const STATIC_CACHE = 'tt-travel-static-v2';
+const RUNTIME_CACHE = 'tt-travel-runtime-v2';
+const API_CACHE = 'tt-travel-api-v2';
+
+const OFFLINE_URL = 'offline.html';
+const PRECACHE_ASSETS = ['.', OFFLINE_URL, 'manifest.json', 'vite.svg'];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches
+      .open(STATIC_CACHE)
+      .then((cache) => cache.addAll(PRECACHE_ASSETS))
+      .then(() => self.skipWaiting()),
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  const keep = new Set([STATIC_CACHE, RUNTIME_CACHE, API_CACHE]);
+
+  event.waitUntil(
+    caches
+      .keys()
+      .then((cacheNames) =>
+        Promise.all(
+          cacheNames
+            .filter((cacheName) => !keep.has(cacheName))
+            .map((cacheName) => caches.delete(cacheName)),
+        ),
+      )
+      .then(() => self.clients.claim()),
+  );
+});
+
+const isApiRequest = (requestUrl, request) => {
+  if (request.method !== 'GET') {
+    return false;
+  }
+
+  return requestUrl.origin === self.location.origin && requestUrl.pathname.startsWith('/api/');
+};
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+
+  if (request.method !== 'GET') {
+    return;
+  }
+
+  const requestUrl = new URL(request.url);
+
+  if (isApiRequest(requestUrl, request)) {
+    event.respondWith(staleWhileRevalidate(request, API_CACHE));
+    return;
+  }
+
+  if (request.mode === 'navigate') {
+    event.respondWith(networkFirstNavigation(request));
+    return;
+  }
+
+  if (requestUrl.origin !== self.location.origin) {
+    return;
+  }
+
+  event.respondWith(cacheFirstStatic(request));
+});
+
+async function staleWhileRevalidate(request, cacheName) {
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request);
+
+  const networkPromise = fetch(request)
+    .then((response) => {
+      if (response.ok) {
+        cache.put(request, response.clone());
+      }
+      return response;
+    })
+    .catch(() => null);
+
+  if (cached) {
+    return cached;
+  }
+
+  const networkResponse = await networkPromise;
+  if (networkResponse) {
+    return networkResponse;
+  }
+
+  return new Response(JSON.stringify({ error: 'Offline' }), {
+    status: 503,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function networkFirstNavigation(request) {
+  try {
+    const response = await fetch(request);
+
+    if (response.ok) {
+      const cache = await caches.open(RUNTIME_CACHE);
+      cache.put(request, response.clone());
+    }
+
+    return response;
+  } catch {
+    const cache = await caches.open(RUNTIME_CACHE);
+    const cached = await cache.match(request);
+
+    if (cached) {
+      return cached;
+    }
+
+    const staticCache = await caches.open(STATIC_CACHE);
+    const offlineFallback = await staticCache.match(OFFLINE_URL);
+
+    return offlineFallback || Response.error();
+  }
+}
+
+async function cacheFirstStatic(request) {
+  const cached = await caches.match(request);
+  if (cached) {
+    return cached;
+  }
+
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      const cache = await caches.open(RUNTIME_CACHE);
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    return Response.error();
+  }
+}

--- a/tt-travels/src/App.jsx
+++ b/tt-travels/src/App.jsx
@@ -8,6 +8,7 @@ import AI from './pages/AI'
 import Calendar from './pages/Calendar'
 import Settings from './pages/Settings'
 import Setup from './pages/Setup'
+import InstallAppPrompt from './components/InstallAppPrompt'
 
 function App() {
   return (
@@ -22,6 +23,7 @@ function App() {
 
         <div className="relative mx-auto max-w-7xl px-4 py-6 md:px-6 md:py-8 space-y-6">
           <Navbar />
+          <InstallAppPrompt />
           <main id="main-content" tabIndex={-1} className="glass-panel rounded-3xl p-4 md:p-8">
             <Routes>
               <Route path="/" element={<Home />} />

--- a/tt-travels/src/components/InstallAppPrompt.jsx
+++ b/tt-travels/src/components/InstallAppPrompt.jsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react'
+
+function InstallAppPrompt() {
+  const [promptEvent, setPromptEvent] = useState(null)
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const onBeforeInstallPrompt = (event) => {
+      event.preventDefault()
+      setPromptEvent(event)
+      setVisible(true)
+    }
+
+    const onAppInstalled = () => {
+      setVisible(false)
+      setPromptEvent(null)
+    }
+
+    window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+    window.addEventListener('appinstalled', onAppInstalled)
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+      window.removeEventListener('appinstalled', onAppInstalled)
+    }
+  }, [])
+
+  const install = async () => {
+    if (!promptEvent) {
+      return
+    }
+
+    await promptEvent.prompt()
+    const result = await promptEvent.userChoice
+
+    if (result.outcome !== 'accepted') {
+      setVisible(false)
+    }
+
+    setPromptEvent(null)
+  }
+
+  if (!visible) {
+    return null
+  }
+
+  return (
+    <div className="glass-panel rounded-2xl p-4 md:p-5 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+      <div>
+        <p className="font-semibold text-slate-100">Install TT&apos;s Travels</p>
+        <p className="text-sm text-slate-300">Get quicker access with an app-like home screen experience.</p>
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => setVisible(false)}
+          className="rounded-lg px-3 py-2 text-sm text-slate-200 hover:text-white hover:bg-white/10"
+        >
+          Maybe later
+        </button>
+        <button
+          type="button"
+          onClick={install}
+          className="rounded-lg px-4 py-2 text-sm font-semibold text-slate-900 bg-slate-100 hover:bg-white"
+        >
+          Install app
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default InstallAppPrompt

--- a/tt-travels/src/components/InstallAppPrompt.jsx
+++ b/tt-travels/src/components/InstallAppPrompt.jsx
@@ -33,10 +33,7 @@ function InstallAppPrompt() {
     await promptEvent.prompt()
     const result = await promptEvent.userChoice
 
-    if (result.outcome !== 'accepted') {
-      setVisible(false)
-    }
-
+    setVisible(false)
     setPromptEvent(null)
   }
 

--- a/tt-travels/src/main.jsx
+++ b/tt-travels/src/main.jsx
@@ -8,3 +8,13 @@ createRoot(document.getElementById('root')).render(
     <App />
   </StrictMode>,
 )
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    const serviceWorkerPath = `${import.meta.env.BASE_URL}service-worker.js`
+
+    navigator.serviceWorker.register(serviceWorkerPath, { scope: import.meta.env.BASE_URL }).catch((error) => {
+      console.warn('Service worker registration failed', error)
+    })
+  })
+}

--- a/tt-travels/src/main.jsx
+++ b/tt-travels/src/main.jsx
@@ -13,8 +13,20 @@ if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     const serviceWorkerPath = `${import.meta.env.BASE_URL}service-worker.js`
 
-    navigator.serviceWorker.register(serviceWorkerPath, { scope: import.meta.env.BASE_URL }).catch((error) => {
-      console.warn('Service worker registration failed', error)
-    })
+    if (import.meta.env.PROD) {
+      navigator.serviceWorker
+        .register(serviceWorkerPath, { scope: import.meta.env.BASE_URL })
+        .catch((error) => {
+          console.warn('Service worker registration failed', error)
+        })
+    } else {
+      navigator.serviceWorker
+        .getRegistrations()
+        .then((registrations) => {
+          for (const registration of registrations) {
+            registration.unregister().catch(() => {})
+          }
+        })
+    }
   })
 }


### PR DESCRIPTION
### Motivation
- Add progressive web app support so the app is installable and resilient offline while preserving the existing static + Vite/GitHub Pages workflow. 
- Keep changes minimal and dependency-free so the current build and dev servers continue to work unchanged. 
- Provide a user-friendly install prompt and graceful offline fallback without touching existing API/OAuth flows. 

### Description
- Added `tt-travels/public/manifest.json` with `start_url`, `scope`, `display`, theme/background colors, and a relative icon so it works from root or subpaths. 
- Implemented `tt-travels/public/service-worker.js` with versioned caches, old-cache cleanup, cache-first static strategy, network-first navigation fallback to `offline.html`, and stale-while-revalidate for same-origin `/api/*` GETs. 
- Added `tt-travels/public/offline.html` as the offline navigation fallback and wired a `<link rel="manifest">` plus mobile web app meta tags into `tt-travels/index.html`. 
- Registered the service worker in `tt-travels/src/main.jsx` using `import.meta.env.BASE_URL` for correct base-path scope and added a lightweight `InstallAppPrompt` React component rendered under the navbar to handle `beforeinstallprompt`/`appinstalled`. 

### Testing
- Ran linting with `cd tt-travels && npm run lint` and the linter completed successfully. 
- Built production assets with `cd tt-travels && npm run build` and the build finished successfully. 
- Verified the Vite build output contains the updated `dist/index.html` and that no new dependencies were introduced during the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc7e498d0c833398ebb1564c3173fd)